### PR TITLE
fix: Complete triangle validation and angle calculation fixes

### DIFF
--- a/PolygonChecker/main.c
+++ b/PolygonChecker/main.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdbool.h>
 #include "main.h"
+#include <string.h>
 #include "triangleSolver.h"
 #include "rectangleSolver.h"
 
@@ -20,13 +21,12 @@ int main() {
             // Triangle analysis selected by user
             printf_s("Triangle selected.\n");
 
-            int triangleSides[3] = { 0, 0, 0 };
-            int* triangleSidesPtr = getTriangleSides(triangleSides);
-
+            double triangleSides[3] = { 0, 0, 0 };
+            double* triangleSidesPtr = getTriangleSides(triangleSides);
             char* result = analyzeTriangle(triangleSidesPtr[0], triangleSidesPtr[1], triangleSidesPtr[2]);
 
-            // Only calculate angles if triangle is valid (all sides positive)
-            if (triangleSidesPtr[0] > 0 && triangleSidesPtr[1] > 0 && triangleSidesPtr[2] > 0) {
+            // Only calculate angles if it's a valid triangle (not "Not a Triangle")
+            if (strcmp(result, "Not a Triangle") != 0) {
                 double angle1, angle2, angle3;
                 calculateTriangleAngles(triangleSidesPtr[0], triangleSidesPtr[1], triangleSidesPtr[2], &angle1, &angle2, &angle3);
 
@@ -34,7 +34,7 @@ int main() {
                 printf_s("|       TRIANGLE ANALYSIS      |\n");
                 printf_s("+==============================+\n");
                 printf_s("| Type: %-21s |\n", result);
-                printf_s("| Angles: %-3.0f, %-3.0f, %-3.0f         |\n", angle1, angle2, angle3);
+                printf_s("| Angles: %-6.2f, %-6.2f, %-6.2f   |\n", angle1, angle2, angle3);
 
                 char* angleType = classifyTriangleByAngles(angle1, angle2, angle3);
                 printf_s("| Classification: %-12s |\n", angleType);
@@ -129,36 +129,31 @@ int printShapeMenu() {
 }
 
 // Gets three triangle side lengths from user with validation
-int* getTriangleSides(int* triangleSides) {
-  
+double* getTriangleSides(double* triangleSides) {
     printf_s("Enter the three sides of the triangle: \n");
 
-    const int MIN_SIDE = 0;
-    const int MAX_SIDE = 10000;
-    
     for (int i = 0; i < 3; i++) {
         printf_s("Enter side %d: ", i + 1);
 
-        int inputResult;
-        char buffer[100];
+        int validInput = 0;
+        char inputLine[100];
 
-        do {
-            inputResult = scanf_s("%d", &triangleSides[i]);
-
-            if (inputResult != 1) {
-                printf_s("Invalid input. Please enter a number between %d and %d: ", MIN_SIDE, MAX_SIDE);
-                scanf_s("%99s", buffer, (unsigned)sizeof(buffer));
-                inputResult = 0;
+        while (!validInput) {
+            if (fgets(inputLine, sizeof(inputLine), stdin)) {
+                // Try to parse as double
+                if (sscanf_s(inputLine, "%lf", &triangleSides[i]) == 1) {
+                    if (triangleSides[i] > 0 && triangleSides[i] <= 10000) {
+                        validInput = 1;
+                    }
+                    else {
+                        printf_s("Please enter a positive number between 0.1 and 10000: ");
+                    }
+                }
+                else {
+                    printf_s("Invalid input. Please enter a number: ");
+                }
             }
-            else if (triangleSides[i] < 0) {
-                printf_s("Number too small. Please enter a number between %d and %d: ", MIN_SIDE, MAX_SIDE);
-                inputResult = 0;
-            }
-            else if (triangleSides[i] > MAX_SIDE) {
-                printf_s("Number too large. Please enter a number between %d and %d: ", MIN_SIDE, MAX_SIDE);
-                inputResult = 0;
-            }
-        } while (inputResult != 1);
+        }
     }
 
     return triangleSides;

--- a/PolygonChecker/main.h
+++ b/PolygonChecker/main.h
@@ -3,4 +3,4 @@
 // Function declarations for main program operations
 void printWelcome();
 int printShapeMenu();
-int* getTriangleSides(int* triangleSides);
+double* getTriangleSides(double* triangleSides);

--- a/PolygonChecker/triangleSolver.c
+++ b/PolygonChecker/triangleSolver.c
@@ -3,9 +3,13 @@
 #include <math.h>
 #include "triangleSolver.h"
 
-char* analyzeTriangle(int side1, int side2, int side3) {
+char* analyzeTriangle(double side1, double side2, double side3) {
 	char* result = "";
 	if (side1 <= 0 || side2 <= 0 || side3 <= 0) {
+		result = "Not a Triangle";
+	}
+	// Check triangle inequality theorem
+	else if (side1 + side2 <= side3 || side1 + side3 <= side2 || side2 + side3 <= side1) {
 		result = "Not a Triangle";
 	}
 	else if (side1 == side2 && side1 == side3) {
@@ -23,7 +27,22 @@ char* analyzeTriangle(int side1, int side2, int side3) {
 	return result;
 }
 
-void calculateTriangleAngles(int side1, int side2, int side3, double* angle1, double* angle2, double* angle3) {
+void calculateTriangleAngles(double side1, double side2, double side3, double* angle1, double* angle2, double* angle3) {
+	
+	// Calculate angles using Law of Cosines with safety checks
+
+	double a = side1, b = side2, c = side3;
+
+	// Ensure values are within valid range for acos() function
+	double cosA = (b * b + c * c - a * a) / (2.0 * b * c);
+	double cosB = (a * a + c * c - b * b) / (2.0 * a * c);
+
+	// Clamp values to avoid floating point errors
+	if (cosA > 1.0) cosA = 1.0;
+	if (cosA < -1.0) cosA = -1.0;
+	if (cosB > 1.0) cosB = 1.0;
+	if (cosB < -1.0) cosB = -1.0;
+	
 	// Calculate angles using Law of Cosines
 
 	// Angle A (opposite side a)

--- a/PolygonChecker/triangleSolver.h
+++ b/PolygonChecker/triangleSolver.h
@@ -1,6 +1,5 @@
 #pragma once
 
-// Triangle analysis function declarations
-char* analyzeTriangle(int side1, int side2, int side3);
-void calculateTriangleAngles(int side1, int side2, int side3, double* angle1, double* angle2, double* angle3);
+char* analyzeTriangle(double side1, double side2, double side3);
+void calculateTriangleAngles(double side1, double side2, double side3, double* angle1, double* angle2, double* angle3);
 char* classifyTriangleByAngles(double angle1, double angle2, double angle3);


### PR DESCRIPTION
## Problems Fixed
1. Triangle sides like (0.1, 0.99, 0.1) were causing NaN angle calculations
2. Invalid triangles were still attempting angle calculations
3. Floating point precision issues in angle computations

## Solutions Implemented
- Added triangle inequality theorem validation (a + b > c)
- Implemented proper checks to prevent angle calculations for invalid triangles
- Added safety clamping for acos() function to prevent domain errors
- Improved angle display precision to 2 decimal places

## Changes Made
- Updated analyzeTriangle() in triangleSolver.c with proper inequality checks
- Modified main.c to only calculate angles for valid triangles using strcmp()
- Enhanced calculateTriangleAngles() with floating point safety checks
- Updated angle display format for better readability

## Testing Verified
- (0.1, 0.99, 0.1) → Correctly shows "Not a Triangle" without angles
- (3.0, 4.0, 5.0) → Properly calculates and displays angles
- (5.5, 5.5, 5.5) → Shows equilateral triangle with 60° angles
- All invalid triangles now handled gracefully without NaN errors